### PR TITLE
Making fields more specific

### DIFF
--- a/examples/example.fasta
+++ b/examples/example.fasta
@@ -1,33 +1,33 @@
 ;~schema: https://raw.githubusercontent.com/FFRGS/FFRGS-Specification/main/ffrgs.json
 ;~schemaVersion: 1
+;~taxon:
+;~name: Bombas huntii
+;~uri: https://identifiers.org/taxonomy:9606
 ;~genome: Bombas huntii
 ;~version: 0.0.1
 ;~metadataAuthor:
-;~  name: Adam Wright
-;~  uri: https://orcid.org/0000-0002-5719-4024 
+;~- name: Adam Wright
+;~uri: https://orcid.org/0000-0002-5719-4024
 ;~assemblyAuthor:
-;~  name: David Molik
-;~  uri: https://orcid.org/0000-0003-3192-6538
+;~- name: David Molik
+;~url: https://orcid.org/0000-0003-3192-6538
 ;~dateCreated: '2022-03-21'
 ;~place:
-;~  name: PBARC
-;~  url: https://www.ars.usda.gov/pacific-west-area/hilo-hi/daniel-k-inouye-us-pacific-basin-agricultural-research-center/
-;~assemblySoftware: HiFiASM
+;~name: PBARC
+;~url: https://www.ars.usda.gov/pacific-west-area/hilo-hi/daniel-k-inouye-us-pacific-basin-agricultural-research-center/
 ;~instrument:
 ;~- Sequel IIe
 ;~- Nanopore
 ;~physicalSample: Located in Freezer 33, Drawer 137
-;~taxon:
-;~  name: Bombas huntii 
-;~  uri: https://identifiers.org/taxonomy:9606
 ;~scholarlyArticle: 10.1371/journal.pntd.0008755
+;~assemblySoftware: HiFiASM
+;~funding: funding
+;~licence: public domain
 ;~documentation: 'Built assembly from... '
 ;~identifier:
 ;~- gkx10242566416842
 ;~relatedLink:
-;~- https/david.molik.co/genome
-;~funding: 'some'
-;~licence: 'public domain'
-;~checksum: 'b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526'
+;~- https://david.molik.co/genome
+;~checksum: 120EA8A25E5D487BF68B5F7096440019234567891234
 >Contig 1
 AAAATCGATCGGCATA

--- a/examples/example.fasta
+++ b/examples/example.fasta
@@ -4,20 +4,23 @@
 ;~version: 0.0.1
 ;~metadataAuthor:
 ;~  name: Adam Wright
-;~  url: https://wormbase.org/resource/person/WBPerson30813
+;~  uri: https://orcid.org/0000-0002-5719-4024 
 ;~assemblyAuthor:
 ;~  name: David Molik
-;~  url: https:/david.molik.co/person
+;~  uri: https://orcid.org/0000-0003-3192-6538
 ;~dateCreated: '2022-03-21'
-;~taxonURL: https://identifiers.org/taxonomy:9606
 ;~place:
 ;~  name: PBARC
 ;~  url: https://www.ars.usda.gov/pacific-west-area/hilo-hi/daniel-k-inouye-us-pacific-basin-agricultural-research-center/
+;~assemblySoftware: HiFiASM
 ;~instrument:
 ;~- Sequel IIe
 ;~- Nanopore
 ;~physicalSample: Located in Freezer 33, Drawer 137
-;~scholarlyArticle: https://doi.org/10.1371/journal.pntd.0008755
+;~taxon:
+;~  name: Bombas huntii 
+;~  uri: https://identifiers.org/taxonomy:9606
+;~scholarlyArticle: 10.1371/journal.pntd.0008755
 ;~documentation: 'Built assembly from... '
 ;~identifier:
 ;~- gkx10242566416842
@@ -25,6 +28,6 @@
 ;~- https/david.molik.co/genome
 ;~funding: 'some'
 ;~licence: 'public domain'
-;~checksum: 'md5:a3d5d9146c3992b7ed6724409ba28aa9'
+;~checksum: 'b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526'
 >Contig 1
 AAAATCGATCGGCATA

--- a/examples/example.json
+++ b/examples/example.json
@@ -3,16 +3,19 @@
     "$id":"https://raw.githubusercontent.com/FFRGS/FFRGS-Specification/main/examples/example.json",
     "schema":"https://raw.githubusercontent.com/FFRGS/FFRGS-Specification/main/ffrgs.json",
     "schemaVersion": 1.0,
-    "taxonURL" : "https://identifiers.org/taxonomy:9606",
+    "taxon" : {
+      "name":"Bombas huntii",
+      "uri": "https://identifiers.org/taxonomy:9606"
+    },
     "genome": "Bombas huntii",
     "version": "0.0.1",
     "metadataAuthor": {
       "name":"Adam Wright",
-      "url":"https://wormbase.org/resource/person/WBPerson30813"
+      "uri":"https://orcid.org/0000-0002-5719-4024"
     },
     "assemblyAuthor": {
       "name":"David Molik",
-      "url":"https:/david.molik.co/person"
+      "url":"https://orcid.org/0000-0003-3192-6538"
     },
    "dateCreated":"2022-03-21",
     "place": {
@@ -28,5 +31,5 @@
     "documentation":"Built assembly from... ",
     "identifier": ["gkx10242566416842"],
     "relatedLink": ["https/david.molik.co/genome"],
-    "checksum":"md5:a3d5d9146c3992b7ed6724409ba28aa9"
+    "checksum":"b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526"
 }

--- a/examples/example.json
+++ b/examples/example.json
@@ -9,14 +9,14 @@
     },
     "genome": "Bombas huntii",
     "version": "0.0.1",
-    "metadataAuthor": {
-      "name":"Adam Wright",
-      "uri":"https://orcid.org/0000-0002-5719-4024"
-    },
-    "assemblyAuthor": {
-      "name":"David Molik",
-      "url":"https://orcid.org/0000-0003-3192-6538"
-    },
+    "metadataAuthor": [
+      { "name":"Adam Wright",
+      "uri":"https://orcid.org/0000-0002-5719-4024" }
+    ],
+    "assemblyAuthor": [
+      { "name":"David Molik",
+      "url":"https://orcid.org/0000-0003-3192-6538" }
+    ],
    "dateCreated":"2022-03-21",
     "place": {
       "name":"PBARC",
@@ -30,6 +30,6 @@
     "licence":"public domain",
     "documentation":"Built assembly from... ",
     "identifier": ["gkx10242566416842"],
-    "relatedLink": ["https/david.molik.co/genome"],
-    "checksum":"b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526"
+    "relatedLink": ["https://david.molik.co/genome"],
+    "checksum":"120EA8A25E5D487BF68B5F7096440019234567891234"
 }

--- a/examples/example.json
+++ b/examples/example.json
@@ -24,7 +24,7 @@
     },     
     "instrument": ["Sequel IIe", "Nanopore"],
     "physicalSample":"Located in Freezer 33, Drawer 137",
-    "scholarlyArticle":"https://doi.org/10.1371/journal.pntd.0008755",
+    "scholarlyArticle":"10.1371/journal.pntd.0008755",
     "assemblySoftware":"HiFiASM",
     "funding":"funding",
     "licence":"public domain",

--- a/examples/example.microdata.html
+++ b/examples/example.microdata.html
@@ -5,17 +5,20 @@
   <span itemprop="genome">Bombas huntii</span>
   <span itemprop="metadataAuthor">  
     <span itemprop="name">Adam Wright</span>  
-    <span itemprop="url">https://wormbase.org/resource/person/WBPerson30813"</span>
+    <span itemprop="uri">https://orcid.org/0000-0002-5719-4024"</span>
   </span>
   <span itemprop="assemblyAuthor">
     <span itemprop="name">David Molik</span>
-    <span itemprop="url">https:/david.molik.co/person"</span>
+    <span itemprop="uri">https://orcid.org/0000-0003-3192-6538"</span>
   </span>
   <span itemprop="place">
     <span itemprop="name">PBARC</span>
     <span itemprop="url">https://www.ars.usda.gov/pacific-west-area/hilo-hi/daniel-k-inouye-us-pacific-basin-agricultural-research-center/"</span>
   </span>
-  <span itemprop="taxonURL">https://identifiers.org/taxonomy:9606</span>
+  <span itemprop="taxon">
+    <span itemprop="name">Bomnas huntii</span>
+    <span itemprop="uri">https://identifiers.org/taxonomy:9606</span>
+  </span>
   <span itemprop="assemblySoftware">HiFiASM</span>
   <span itemprop="physicalSample">Located in Freezer 33, Drawer 137</span>
   <span itemprop="dateCreated">2022-03-21</span>
@@ -27,5 +30,5 @@
   <span itemprop="relatedLink">https/david.molik.co/genome</span>
   <span itemprop="funding">some</span>
   <span itemprop="licence">public domain</span>
-  <span itemprop="checksum">md5:a3d5d9146c3992b7ed6724409ba28aa9</span>
+  <span itemprop="checksum">b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526</span>
 </div>

--- a/examples/example.microdata.html
+++ b/examples/example.microdata.html
@@ -27,7 +27,7 @@
   <span itemprop="scholarlyArticle">https://doi.org/10.1371/journal.pntd.0008755</span>
   <span itemprop="documentation">Built assembly from... </span>
   <span itemprop="identifier">gkx10242566416842</span>
-  <span itemprop="relatedLink">https/david.molik.co/genome</span>
+  <span itemprop="relatedLink">https://david.molik.co/genome</span>
   <span itemprop="funding">some</span>
   <span itemprop="licence">public domain</span>
   <span itemprop="checksum">b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526</span>

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -4,10 +4,10 @@ genome: Bombas huntii
 version: 0.0.1
 metadataAuthor:
   name: Adam Wright
-  url: https://wormbase.org/resource/person/WBPerson30813
+  uri: https://orcid.org/0000-0002-5719-4024 
 assemblyAuthor:
   name: David Molik
-  url: https:/david.molik.co/person
+  uri: https://orcid.org/0000-0003-3192-6538
 dateCreated: '2022-03-21'
 place:
   name: PBARC
@@ -17,8 +17,10 @@ instrument:
 - Sequel IIe
 - Nanopore
 physicalSample: Located in Freezer 33, Drawer 137
-taxonURL: https://identifiers.org/taxonomy:9606
-scholarlyArticle: https://doi.org/10.1371/journal.pntd.0008755
+taxon:
+  name: Bombas huntii 
+  uri: https://identifiers.org/taxonomy:9606
+scholarlyArticle: 10.1371/journal.pntd.0008755
 documentation: 'Built assembly from... '
 identifier:
 - gkx10242566416842
@@ -26,4 +28,4 @@ relatedLink:
 - https/david.molik.co/genome
 funding: 'some'
 licence: 'public domain'
-checksum: 'md5:a3d5d9146c3992b7ed6724409ba28aa9'
+checksum: 'b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526'

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,31 +1,31 @@
 schema: https://raw.githubusercontent.com/FFRGS/FFRGS-Specification/main/ffrgs.json
 schemaVersion: 1
+taxon:
+  name: Bombas huntii
+  uri: https://identifiers.org/taxonomy:9606
 genome: Bombas huntii
 version: 0.0.1
 metadataAuthor:
-  name: Adam Wright
-  uri: https://orcid.org/0000-0002-5719-4024 
+- name: Adam Wright
+  uri: https://orcid.org/0000-0002-5719-4024
 assemblyAuthor:
-  name: David Molik
-  uri: https://orcid.org/0000-0003-3192-6538
+- name: David Molik
+  url: https://orcid.org/0000-0003-3192-6538
 dateCreated: '2022-03-21'
 place:
   name: PBARC
   url: https://www.ars.usda.gov/pacific-west-area/hilo-hi/daniel-k-inouye-us-pacific-basin-agricultural-research-center/
-assemblySoftware: HiFiASM
 instrument:
 - Sequel IIe
 - Nanopore
 physicalSample: Located in Freezer 33, Drawer 137
-taxon:
-  name: Bombas huntii 
-  uri: https://identifiers.org/taxonomy:9606
 scholarlyArticle: 10.1371/journal.pntd.0008755
+assemblySoftware: HiFiASM
+funding: funding
+licence: public domain
 documentation: 'Built assembly from... '
 identifier:
 - gkx10242566416842
 relatedLink:
-- https/david.molik.co/genome
-funding: 'some'
-licence: 'public domain'
-checksum: 'b49259f449a2016fb26c1e52f5ecf5af752c74380110058f21a2820fdc3f8526'
+- https://david.molik.co/genome
+checksum: 120EA8A25E5D487BF68B5F7096440019234567891234

--- a/ffrgs.json
+++ b/ffrgs.json
@@ -17,40 +17,53 @@
       "type": "string",
       "description": "Name of the Genome"
     },
-    "taxonURL":{
-      "type": "string",
-      "description": "URL of the species information"
-    },
-    "version":{
-      "type": "string",
-      "description": "Version number of Genome"
-    },
-    "metadataAuthor":{
+    "taxon":{
       "type": "object",
-      "description": "Author of the FFRGS Instance (Person or Org)",
+      "description": "Species name and URL of the species information at identifiers.org",
       "properties": {
         "name": {
           "type": "string"
         },
-        "url": {
-          "type": "string"
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "https://identifiers.org/taxonomy:[0-9]+"
         }
       }
     },
-    "assemblyAuthor":{
-      "type": "object",
-      "description": "Assembler of the Genome (Person or Org)",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
+    "version":{
+      "type": "number",
+      "description": "Version number of Genome"
+    },
+    "metadataAuthors":{
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "Author of the FFRGS Instance (Person or Org)",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uri": { "$ref": "#/definitions/orcidUri" }
+        }
+      }
+    },
+    "assemblyAuthors":{
+      "type": "array",
+        "items": {
+        "type": "object",
+        "description": "Assembler of the Genome (Person or Org)",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uri": { "$ref": "#/definitions/orcidUri" }
         }
       }
     },
     "dateCreated":{
       "type": "string",
+      "format": "date",
       "description": "Date the genome assembly was created"
     },
     "physicalSample":{
@@ -65,7 +78,8 @@
           "type": "string"
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -95,7 +109,8 @@
       "type": "array",
       "description": "Related URLS to the genome",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "uri"
       }
     },
     "funding": {
@@ -106,8 +121,17 @@
       "type": "string",
       "description": "license for the use of the Genome"
     },
-    "checksum": {
-      "type":"string",
-      "description": "checksum value for hashing"
+    "checksum": { "$ref": "#/definitions/sha2" }
+  },
+  "definitions": {
+    "orcidUri": { "format": "uri", 
+                  "pattern": "^https://orcid.org/[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]" },
+    "sha2": {
+      "type": "string",
+      "minLength": 44,
+      "maxLength": 44,
+      "pattern": "^[A-Za-z0-9/+=]+$",
+      "description": "sha2-512/256 checksum value for hashing"
     }
+  }
 }

--- a/ffrgs.json
+++ b/ffrgs.json
@@ -35,7 +35,7 @@
       "type": "number",
       "description": "Version number of Genome"
     },
-    "metadataAuthors":{
+    "metadataAuthor":{
       "type": "array",
       "items": {
         "type": "object",
@@ -48,7 +48,7 @@
         }
       }
     },
-    "assemblyAuthors":{
+    "assemblyAuthor":{
       "type": "array",
         "items": {
         "type": "object",
@@ -92,7 +92,8 @@
     },
     "scholarlyArticle": {
       "type": "string",
-      "description": "Scholarly article genome was published in"
+      "pattern": "^10.",
+      "description": "Scholarly article genome was published e.g. 10.5281/zenodo.6762550 "
     },
     "documentation": {
       "type": "string",

--- a/ffrgs.json
+++ b/ffrgs.json
@@ -32,8 +32,8 @@
       }
     },
     "version":{
-      "type": "number",
-      "description": "Version number of Genome"
+      "type": "string",
+      "description": "Version number of Genome eg. 1.2.0"
     },
     "metadataAuthor":{
       "type": "array",


### PR DESCRIPTION
Hi David, 

I don't know that we have to pull all of this in but I have not tested it but it validates as correct json-schema.

I have made the two author-related fields into arrays. I have also made it so that we are using the type "URI" and then I am also adding regex patterns for a few field types. Also, I am making it so that we are using sha2. I have not researched to see if this is appropriate or not. I got the idea from https://github.com/elliottslaughter/integrity-checker/blob/master/schema/checksum.json. All I t is doing is checking that we have a string of 44 characters of a specific type. I don't think there is any reason to support the md5 sum.

I have also made it so that our taxonURI is now a name and a URI. This makes it so that it is human-readable and computable. Also makes it so that we are getting the users to use identifiers.org.  

Feel free to modify what you will. This is just my attempt at making this succinct 